### PR TITLE
Fix html builder

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,7 +4,8 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $THIS_DIR/lib/*
 cd $THIS_DIR/..
 LAST_DIR=${OLDPWD}
-BRANCHES=(0.9 1.0 1.1 1.2)
+#BRANCHES=(0.9 1.0 1.1 1.2)
+BRANCHES=(1.0)
 
 function clean() {
   function clean_dir() {
@@ -23,18 +24,12 @@ clean
 function build () {
   echo "Cloning into docs-csm..."
 
+  mkdir -p ./docs-csm
+  cd ./docs-csm
   for branch in ${BRANCHES[@]}; do
-    mkdir -p ./docs-csm/tmp
-    cd ./docs-csm/tmp
-    BACK_DIR=${OLDPWD}
-    git clone git@github.com:Cray-HPE/docs-csm.git
-    mv docs-csm ../$branch
-    cd ../$branch
-    git fetch
-    git checkout "release/$branch" && git pull origin "release/$branch"
-    cd $BACK_DIR
-    sudo rm -rf docs-csm/tmp
+    git clone --depth 1 -b release/$branch git@github.com:Cray-HPE/docs-csm.git ./$branch
   done
+  cd ${OLDPWD}
 
   echo "Preparing markdown for Hugo..."
   docker-compose -f $THIS_DIR/compose/hugo_prep.yml up \

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,8 +4,7 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $THIS_DIR/lib/*
 cd $THIS_DIR/..
 LAST_DIR=${OLDPWD}
-#BRANCHES=(0.9 1.0 1.1 1.2)
-BRANCHES=(1.0)
+BRANCHES=(0.9 1.0 1.1 1.2)
 
 function clean() {
   function clean_dir() {

--- a/bin/convert-docs-to-hugo.sh
+++ b/bin/convert-docs-to-hugo.sh
@@ -69,12 +69,13 @@ function crawl_directory() {
 function process_file() {
     oldtitle=$(get_old_title $1)
     newtitle=$(make_new_title "${oldtitle}")
-    if [[ -z $newtitle ]]; then
-        echo $1
-        echo "Old Title: $oldtitle"
-        echo "No title found"
-        exit 1
-    fi
+    # Exiting with code 1 here does not throw error - just stops processing half way done
+    # if [[ -z $newtitle ]]; then
+    #     echo $1
+    #     echo "Old Title: $oldtitle"
+    #     echo "No title found"
+    #     exit 1
+    # fi
     filename=$(basename $1)
     mid_path=$(echo -n $1 | sed "s|${SOURCE_DIR}||" | sed "s|${filename}||")
     [[ $filename == "index.md" ]] && filename="_index.md"

--- a/bin/lib/content_prep
+++ b/bin/lib/content_prep
@@ -59,11 +59,11 @@ function transform_links() {
     # - fixes image references
     # - replaces <a name="anchor"> format for hugo anchor ref formats
     # - changes index.md to _index.md
-    # e.g. [Who]({{< relref "./about.md#who" >}})
+    # e.g. [Who]({{< relref "." "about.md#who" >}})
     cat $1 | \
     grep -v "stash.us.cray.com" | \
     sed -r 's|\]\(\/|\]\(\.\/|g' | \
-    sed -r 's|\]\(([^)|:]*).md(#.*)?\)|\]\(\{\{\< relref \"\.\/\1.md\2\" \>\}\}\)|g' | \
+    sed -r 's|\]\(([^)|:]*).md(#.*)?\)|\]\(\{\{\< relref \"\.\" \"\1.md\2\" \>\}\}\)|g' | \
     sed -r 's|\]\(([^)|:]*)\.(png\|svg)(#.*)?\)|\]\(\.\./\1\.\2\)|g' | \
     sed -rz 's|<a name="([^"]*)"></a>\s*\n(\s*#+ [^\n]*)|\2 {#\1}|g' | \
     sed 's|\"\"|\"|g' | \


### PR DESCRIPTION
## Summary and Scope

* Clone of docs-csm takes significant time. It's a large repo, with long history of commits, and big diffs between branches. Instead of doing full clone for each release, make shallow (--depth=1) clone of specific branch. This is significantly faster.
* I noticed hrefs generated using relref function are empty. Check current state of https://cray-hpe.github.io/docs-csm/en-10/ - very first link to "Introduction to CSM installation" has empty URL, which means link points to the page it's located at. This change modifies call to relref function of Hugo to take relative content as 1st argument: https://gohugo.io/functions/relref/
* In release/1.2 branch, one of the MD files is missing a space between # and title text: https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/network/network_management_install_guide/aruba/acl.md This leads to convert-docs-to-hugo.sh script interruption, which leaves documents half way prepared for Hugo processing. I.e. no error reported, just half of documents is (almost) silently missing. Check https://cray-hpe.github.io/docs-csm/en-12/ - it's missing several items in left menu, comparing to 1.1. I've removed check for an empty title - Hugo seems to be fine with empty titles.