### PR TITLE
CRAYSAT-1343: Add SAT support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 content/
 docs-csm/
+docs-sat/
 public/
 .DS_Store
 csm_docs_build.log
+sat_docs_build.log

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This repo contains the build tools and templates necessary to transform markdown
 1. Run `bin/build.sh`.  (This creates a public folder with the html.)
 1. Run `bin/dev.sh` and view the result at http://localhost/csm
 
+## Building SAT docs
+You can build SAT docs using the same scripts as the CSM docs use.
+1. Make sure you have Docker and Docker Compose installed and access to checkout the SAT docs repo (see conf/sat.sh)
+1. Run `build/build.sh sat`.
+1. Run `bin/dev.sh sat` and view the result at http://localhost/docs-sat
+
 ## TODO
 1. Fix the remaining broken links.
 1. Integrate with a CI job.

--- a/bin/compose/sat/hugo_build.sat.yml
+++ b/bin/compose/sat/hugo_build.sat.yml
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # MIT License
 #
@@ -22,29 +21,15 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-set -ex
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd $THIS_DIR/..
-LAST_DIR=${OLDPWD}
+version: '3'
 
-# Default product is CSM to maintain backward compatibility
-PRODUCT_NAME=${1:-csm}
-# shellcheck source=conf/csm.sh
-source "${THIS_DIR}/../conf/${PRODUCT_NAME}.sh"
-
-function test_links() {
-  echo "Test links in HTML pages..."
-
-  # Standup the nginx server as a background daemon first
-  docker-compose -f "${THIS_DIR}/compose/${HUGO_TEST_COMPOSE_FILE}" up --force-recreate --no-color --remove-orphans -d serve_static
-
-  # Crawl the links for each version
-  docker-compose -f "${THIS_DIR}/compose/${HUGO_TEST_COMPOSE_FILE}" up --no-color --remove-orphans \
-  "${LINKCHECK_SERVICE_NAMES[@]}" | tee -a csm_docs_build.log
-
-  # Tear it all down
-  docker-compose -f "${THIS_DIR}/compose/${HUGO_TEST_COMPOSE_FILE}" down
-}
-test_links
-
-cd $LAST_DIR
+services:
+  hugo_build:
+    container_name: hugo_build
+    command: --config /src/config.sat.toml
+    # image: peaceiris/hugo:v0.x.x
+    # image: peaceiris/hugo:v0.84.4-mod   # Hugo Modules
+    image: peaceiris/hugo:v0.84.4-full  # Hugo Modules and Node.js
+    volumes:
+      - ${PWD}:/src
+    working_dir: /src

--- a/bin/compose/sat/hugo_prep.sat.yml
+++ b/bin/compose/sat/hugo_prep.sat.yml
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # MIT License
 #
@@ -22,29 +21,49 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-set -ex
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd $THIS_DIR/..
-LAST_DIR=${OLDPWD}
 
-# Default product is CSM to maintain backward compatibility
-PRODUCT_NAME=${1:-csm}
-# shellcheck source=conf/csm.sh
-source "${THIS_DIR}/../conf/${PRODUCT_NAME}.sh"
+version: '3'
 
-function test_links() {
-  echo "Test links in HTML pages..."
-
-  # Standup the nginx server as a background daemon first
-  docker-compose -f "${THIS_DIR}/compose/${HUGO_TEST_COMPOSE_FILE}" up --force-recreate --no-color --remove-orphans -d serve_static
-
-  # Crawl the links for each version
-  docker-compose -f "${THIS_DIR}/compose/${HUGO_TEST_COMPOSE_FILE}" up --no-color --remove-orphans \
-  "${LINKCHECK_SERVICE_NAMES[@]}" | tee -a csm_docs_build.log
-
-  # Tear it all down
-  docker-compose -f "${THIS_DIR}/compose/${HUGO_TEST_COMPOSE_FILE}" down
-}
-test_links
-
-cd $LAST_DIR
+services:
+  hugo_prep_21:
+    container_name: hugo_prep_21
+    image: ubuntu
+    environment:
+      DOCS_BRANCH: 2.1
+      PRODUCT_NAME: sat
+    volumes:
+      - ${PWD}:/src
+    entrypoint:
+      - /src/bin/convert-docs-to-hugo.sh
+      - --source
+      - /src/docs-sat/
+      - --destination
+      - /src/content/
+  hugo_prep_22:
+    container_name: hugo_prep_22
+    image: ubuntu
+    environment:
+      DOCS_BRANCH: 2.2
+      PRODUCT_NAME: sat
+    volumes:
+      - ${PWD}:/src
+    entrypoint:
+      - /src/bin/convert-docs-to-hugo.sh
+      - --source
+      - /src/docs-sat/
+      - --destination
+      - /src/content
+  hugo_prep_23:
+    container_name: hugo_prep_23
+    image: ubuntu
+    environment:
+      DOCS_BRANCH: 2.3
+      PRODUCT_NAME: sat
+    volumes:
+      - ${PWD}:/src
+    entrypoint:
+      - /src/bin/convert-docs-to-hugo.sh
+      - --source
+      - /src/docs-sat/
+      - --destination
+      - /src/content

--- a/bin/compose/sat/test.sat.yml
+++ b/bin/compose/sat/test.sat.yml
@@ -1,0 +1,76 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+version: '3'
+
+services:
+
+  serve_static:
+    container_name: sat_local_nginx
+    image: nginx
+    volumes:
+      - ${PWD}/public:/usr/share/nginx/html/docs-sat:ro
+    ports:
+      - "80:80"
+    networks:
+      sat_documentation:
+        ipv4_address: 10.253.252.2
+  linkcheck_en_21:
+    build: ${PWD}/bin/compose/build/linkchecker
+    container_name: sat_docs_linkcheck_21
+    depends_on:
+      - serve_static
+    image: filiph/linkcheck
+    command:
+      - http://10.253.252.2/docs-sat/en-21
+    networks:
+      sat_documentation:
+        ipv4_address: 10.253.252.3
+  linkcheck_en_22:
+    build: ${PWD}/bin/compose/build/linkchecker
+    container_name: sat_docs_linkcheck_22
+    depends_on:
+      - serve_static
+    image: filiph/linkcheck
+    command:
+      - http://10.253.252.2/docs-sat/en-22
+    networks:
+      sat_documentation:
+        ipv4_address: 10.253.252.4
+  linkcheck_en_23:
+    build: ${PWD}/bin/compose/build/linkchecker
+    container_name: sat_docs_linkcheck_23
+    depends_on:
+      - serve_static
+    image: filiph/linkcheck
+    command:
+      - http://10.253.252.2/docs-sat/en-23
+    networks:
+      sat_documentation:
+        ipv4_address: 10.253.252.5
+networks:
+  sat_documentation:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.253.252.0/24

--- a/bin/dev.sh
+++ b/bin/dev.sh
@@ -27,6 +27,11 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $THIS_DIR/lib/*
 cd $THIS_DIR/..
 
-docker-compose -f $THIS_DIR/compose/test.yml up \
+# Default product is CSM to maintain backward compatibility
+PRODUCT_NAME=${1:-csm}
+# shellcheck source=conf/csm.sh
+source "${THIS_DIR}/../conf/${PRODUCT_NAME}.sh"
+
+docker-compose -f "${THIS_DIR}/compose/${HUGO_TEST_COMPOSE_FILE}" up \
     --force-recreate --no-color --remove-orphans serve_static
 

--- a/bin/lib/content_prep
+++ b/bin/lib/content_prep
@@ -45,7 +45,8 @@ function make_new_title() {
     sed -r 's`[C,c]rus`CRUS`' | \
     sed -r 's`[C,c]an`CAN`' | \
     sed -r 's`[P,p]xe`PXE`' | \
-    sed -r 's`[A,a]cl`ACL`'
+    sed -r 's`[A,a]cl`ACL`' | \
+    sed -r 's`[S,s]at`SAT`'
 }
 
 function transform_links() {
@@ -62,13 +63,14 @@ function transform_links() {
     # - replaces <a name="anchor"> format for hugo anchor ref formats
     # - changes index.md to '' - for some reason Hugo silently puts empty href, if source href points
     #   to _index.md file. So we just point to directory instead.
+    index_file=${2:-index.md}
     cat $1 | \
     grep -v "stash.us.cray.com" | \
     sed -r 's|\]\(\/|\]\(\.\/|g' | \
     sed -r 's|\]\(([^)|:]*).md(#.*)?\)|\]\(\{\{\< relref \"\.\/\1.md\2\" \>\}\}\)|g' | \
     sed -r 's|\]\(([^)|:]*)\.(png\|svg)(#.*)?\)|\]\(\.\./\1\.\2\)|g' | \
     sed -rz 's|<a name="([^"]*)"></a>\s*\n(\s*#+ [^\n]*)|\2 {#\1}|g' | \
-    sed 's|index.md||g'
+    sed "s|$index_file||g"
 }
 
 function gen_hugo_yaml() {

--- a/conf/csm.sh
+++ b/conf/csm.sh
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Contains configuration variables for building csm docs.
+
+# A list of releases that should be built. Each entry should be X.Y where the
+# branch release/X.Y exists in the docs repo.
+export BRANCHES=("0.9" "1.0" "1.2")
+
+# The documentation repository remote URL. It must be possible to run
+# 'git clone $DOCS_REPO_REMOTE_URL'.
+export DOCS_REPO_REMOTE_URL="git@github.com:Cray-HPE/docs-csm.git"
+
+# The name of the log file.
+export LOG_FILE="csm_docs_build.log"
+
+# The local directory to which the documentation repository should be cloned.
+export DOCS_REPO_LOCAL_DIR="docs-csm"
+
+# The title that should appear at the top of the HTML docs.
+export DOC_TITLE="CSM Documentation"
+
+# The branch to which the HTML docs should be pushed.
+export DOCS_HTML_RELEASE_BRANCH="release/docs-html"
+
+# The path to the docker-compose YAML file that should be used for Hugo prep
+# (relative to the compose/ directory).
+export HUGO_PREP_COMPOSE_FILE="hugo_prep.yml"
+
+# The path to the docker-compose YAML File that should be used for Hugo build
+# (relative to the compose/ directory).
+export HUGO_BUILD_COMPOSE_FILE="hugo_build.yml"
+
+# The path to the docker-compose YAML file that should be used for Hugo tests.
+# (relative to the compose/ directory).
+export HUGO_TEST_COMPOSE_FILE="test.yml"
+
+# The path to the docker-compose YAML file that should be used for the Hugo
+# local development server (relative to the compose/ directory).
+export HUGO_DEV_SERVER_COMPOSE_FILE="dev_serve.yml"
+
+# The names of the "linkcheck" services in $HUGO_TEST_COMPOSE_FILE
+export LINKCHECK_SERVICE_NAMES=("linkcheck_en_09" "linkcheck_en_10" "linkcheck_en_11" "linkcheck_en_12")
+
+# The name of the "index" files that should be converted to _index.md files in
+# convert-docs-to-hugo.sh
+export INDEX_FILE_NAME="index.md"

--- a/conf/sat.sh
+++ b/conf/sat.sh
@@ -1,0 +1,68 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Contains configuration variables for building sat docs.
+#
+
+# A list of releases that should be built. Each entry should be X.Y where the
+# branch release/X.Y exists in the docs repo.
+export BRANCHES=("2.3" "2.2" "2.1")
+
+# The documentation repository remote URL. It must be possible to run
+# 'git clone $DOCS_REPO_REMOTE_URL'.
+export DOCS_REPO_REMOTE_URL="git@github.hpe.com:eli-kamin/docs-sat.git"
+
+# The name of the log file.
+export LOG_FILE="sat_docs_build.log"
+
+# The local directory to which the documentation repository should be cloned.
+export DOCS_REPO_LOCAL_DIR="docs-sat"
+
+# The title that should appear at the top of the HTML docs.
+export DOC_TITLE="SAT Documentation"
+
+# The branch to which the HTML docs should be pushed.
+export DOCS_HTML_RELEASE_BRANCH="release/docs-html"
+
+# The path to the docker-compose YAML file that should be used for Hugo prep
+# (relative to the compose/ directory).
+export HUGO_PREP_COMPOSE_FILE="sat/hugo_prep.sat.yml"
+
+# The path to the docker-compose YAML File that should be used for Hugo build
+# (relative to the compose/ directory).
+export HUGO_BUILD_COMPOSE_FILE="sat/hugo_build.sat.yml"
+
+# The path to the docker-compose YAML file that should be used for Hugo tests.
+# (relative to the compose/ directory).
+export HUGO_TEST_COMPOSE_FILE="sat/test.sat.yml"
+
+# The path to the docker-compose YAML file that should be used for the Hugo
+# local development server (relative to the compose/ directory).
+export HUGO_DEV_SERVER_COMPOSE_FILE="dev_serve.yml"
+
+# The names of the "linkcheck" services in $HUGO_TEST_COMPOSE_FILE
+export LINKCHECK_SERVICE_NAMES=("linkcheck_en_21" "linkcheck_en_22" "linkcheck_en_23")
+
+# The name of the "index" files that should be converted to _index.md files in
+# convert-docs-to-hugo.sh
+export INDEX_FILE_NAME="README.md"

--- a/config.sat.toml
+++ b/config.sat.toml
@@ -1,0 +1,34 @@
+title = "System Admin Toolkit (SAT)"
+theme = "hugo-theme-learn"
+baseURL = "/docs-sat/"
+languageCode = "en-US"
+defaultContentLanguage = "en-23"
+defaultContentLanguageInSubdir = true
+showVisitedLinks = true
+refLinksErrorLevel = "WARNING"
+
+[outputs]
+home = ["HTML", "RSS", "JSON" ]
+
+[params]
+shortTitle = "System Admin Toolkit"
+themeVariant = "blue"
+disableNextPrev = true
+disableLandingPageButton = true
+
+[languages]
+  [languages.en-23]
+    contentDir = "content/2.3"
+    languageName = "2.3"
+    weight = 40
+    landingPageURL = "/docs-sat/en-23"
+  [languages.en-22]
+    contentDir = "content/2.2"
+    languageName = "2.2"
+    weight = 40
+    landingPageURL = "/docs-sat/en-22"
+  [languages.en-21]
+    contentDir = "content/2.1"
+    languageName = "2.1"
+    weight = 40
+    landingPageURL = "/docs-sat/en-21"

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,7 @@ refLinksErrorLevel = "WARNING"
 home = ["HTML", "RSS", "JSON" ]
 
 [params]
+shortTitle = "Cray System Management"
 themeVariant = "blue"
 disableNextPrev = true
 disableLandingPageButton = true

--- a/themes/hugo-theme-learn/layouts/partials/logo.html
+++ b/themes/hugo-theme-learn/layouts/partials/logo.html
@@ -1,3 +1,3 @@
 <a id="logo" href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "/") }}'>
-  Cray System Management
+  {{ .Site.Params.shortTitle }}
 </a>


### PR DESCRIPTION
## Original Commit Message

```
This commit modifies the build scripts so that they source a config file
which contains product-specific configuration values, so that the scripts
are not hard-coded to CSM. To build documentation for SAT, give
a positional argument to the build script, e.g. `bin/build.sh sat`.
To maintain backward compatibility, running the scripts without any
arguments will continue to build the CSM docs.

This script adds two config files in conf/
* csm.sh (default)
* sat.sh

A couple other files are modified for SAT support:
* docker-compose files are split up, adding sat-specific compose files
  in bin/compose/sat/. These files are referred to in sat.sh.
* A new Hugo config file, config.sat.toml is added at the top of this
  repo. It defines the different "languages" which are actually used for
  switching between versions.
* The Hugo config files get a new parameter called shortTitle. This is
  referred to in themes/hugo-theme-learn/layouts/partials/logo.html
  rather than hard-coding the doc title in the theme.
* README.md is modified to provide some short instructions on how to
  build the SAT docs.
* Modify convert-docs-to-hugo.sh so that the value "index.md" is
  configurable, so that a repo that uses README.md files as the index
  can be built in the same way.

Finally, add sat_docs_build.log and sat-docs to .gitignore.

Test Description:
* I ran the following scripts with no arguments to make sure CSM
  docs were still building as expected:
  * bin/build.sh
  * bin/dev.sh
  * bin/test.sh
  * bin/push.sh (For this test, I commented out the line that actually
    performs the push).
* Next, I ran the following to test building SAT docs:
  * bin/build.sh sat
  * bin/dev.sh sat
  * bin/test.sh sat
  * bin/push.sh sat
```

## Summary and Scope

This change adds support for building SAT docs using the csm-docs-html-builder code. It does this by adding support for a configuration file, e.g. `conf/csm.sh` or `conf/sat.sh`. The default behavior is to build CSM docs, so this change is fully backward compatible.

## Issues and Related PRs

* CRAYSAT-1341

## Testing

### Tested on:

  * Local development environment

### Test description:

See commit message

## Risks and Mitigations

N/A

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated (N/A)
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable (N/A)

