### PR TITLE
CRAYSAT-1450: Add workflow to publish docs

### DIFF
--- a/.github/workflows/build-sat-docs.yaml
+++ b/.github/workflows/build-sat-docs.yaml
@@ -1,0 +1,65 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: Generate SAT Docs
+
+on:
+  push:
+  schedule:
+   # 3AM UTC / 11PM EST / 8PM PST
+   - cron:  '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Cleanup runner
+        run: |
+          # Containers may have written files owned by root onto mounted volumes
+          sudo rm -rf csm-docs-html-builder
+
+      - name: Setup SSH keys
+        uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.DEPLOYKEY_WRITE_DOCS_CSM }}
+
+      - name: Check out csm-docs-html-builder repository
+        uses: actions/checkout@v2
+        with:
+          path: csm-docs-html-builder
+
+      - name: Run generator
+        run: ./bin/build.sh sat
+        working-directory: csm-docs-html-builder
+
+      - name: Push generated HTML
+        if: success() && github.ref == 'refs/heads/master'
+        env:
+          GIT_AUTHOR_NAME: "Cray-HPE Github Bot"
+          GIT_AUTHOR_EMAIL: noreply@hpe.com
+          GIT_COMMITTER_NAME: "Cray-HPE Github Bot"
+          GIT_COMMITTER_EMAIL: noreply@hpe.com
+        run: ./bin/push.sh sat
+        working-directory: csm-docs-html-builder

--- a/conf/sat.sh
+++ b/conf/sat.sh
@@ -42,7 +42,7 @@ export DOCS_REPO_LOCAL_DIR="docs-sat"
 export DOC_TITLE="SAT Documentation"
 
 # The branch to which the HTML docs should be pushed.
-export DOCS_HTML_RELEASE_BRANCH="release/docs-html"
+export DOCS_HTML_RELEASE_BRANCH="publish/docs-html"
 
 # The path to the docker-compose YAML file that should be used for Hugo prep
 # (relative to the compose/ directory).


### PR DESCRIPTION
## Summary and Scope

This changes the value of DOCS_HTML_RELEASE_BRANCH in the configuration, and adds a GitHub workflow to publish to that branch, based on the equivalent workflow of CSM.

## Issues and Related PRs

CRAYSAT-1450

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

