### PR TITLE
CRAYSAT-1450: Update ssh key name

### DIFF
--- a/.github/workflows/build-sat-docs.yaml
+++ b/.github/workflows/build-sat-docs.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup SSH keys
         uses: webfactory/ssh-agent@v0.5.3
         with:
-          ssh-private-key: ${{ secrets.DEPLOYKEY_WRITE_DOCS_CSM }}
+          ssh-private-key: ${{ secrets.DEPLOYKEY_WRITE_DOCS_SAT }}
 
       - name: Check out csm-docs-html-builder repository
         uses: actions/checkout@v2


### PR DESCRIPTION
A new deploy key was generated and was given write access to docs-sat.
This commit updates the name of the secret used in the workflow that
pushes to docs-sat.

## Summary and Scope

A new deploy key was generated and was given write access to docs-sat.
This commit updates the name of the secret used in the workflow that
pushes to docs-sat.

## Issues and Related PRs

CRAYSAT-1450

## Testing

### Tested on:

  * GitHub workflow

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

