### PR TITLE
Add error processing for hugo_prep stage

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -61,10 +61,17 @@ function build () {
   cd ${OLDPWD}
 
   echo "Preparing markdown for Hugo..."
+  set +e
   docker-compose -f "${THIS_DIR}/compose/${HUGO_PREP_COMPOSE_FILE}" up \
-    --force-recreate --no-color --remove-orphans | \
+    --force-recreate --no-color --remove-orphans --abort-on-container-exit | \
   tee -a "$LOG_FILE"
+  exit_code=${PIPESTATUS[0]}
   docker-compose -f "${THIS_DIR}/compose/${HUGO_PREP_COMPOSE_FILE}" down
+  set -e
+  if [ $exit_code -ne 0 ]; then
+    echo "Exiting due to Hugo preparation errors above ..."
+    exit $exit_code
+  fi
 
   echo "Creating root _index.md"
   gen_hugo_yaml "$DOC_TITLE" > content/_index.md


### PR DESCRIPTION
## Summary and Scope

Previously, errors happening in containers at `hugo_prep` stage were swallowed. This could result in empty content being committed and pushed to `publish/docs-html` branch, as reported in [CRAYSAT-1484](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1484). This change add error processing for `hugo_prep` stage, similar to existing processing at `hugo_build` stage.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Relates to [CRAYSAT-1484](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1484)

## Testing
### Tested on:

   * locally
   * Github CI

### Test description:

Tested locally:

  * By adding `exit 1` to `bin/convert-docs-to-hugo.sh` - to test that builds fails, if error happens in `bin/convert-docs-to-hugo.sh`
  * By setting non-existent image name into one of `hugo_prep` services in `bin/sat/hugo_prep.sat.yaml`
  
In both cases, build was aborted and error reported.
