### PR TITLE
CASMINST-5196 Add CSM 1.3 branch to HTML docs

### DIFF
--- a/bin/compose/hugo_prep.yml
+++ b/bin/compose/hugo_prep.yml
@@ -76,3 +76,16 @@ services:
       - /src/docs-csm/
       - --destination
       - /src/content/
+  hugo_prep_13:
+    container_name: hugo_prep_13
+    image: ubuntu
+    environment:
+      CSM_BRANCH: 1.3
+    volumes:
+      - ${PWD}:/src
+    entrypoint:
+      - /src/bin/convert-docs-to-hugo.sh
+      - --source
+      - /src/docs-csm/
+      - --destination
+      - /src/content/

--- a/bin/compose/test.yml
+++ b/bin/compose/test.yml
@@ -79,6 +79,17 @@ services:
     networks:
       csm_documentation:
         ipv4_address: 10.253.253.6
+  linkcheck_en_13:
+    build: ${PWD}/bin/compose/build/linkchecker
+    container_name: csm_docs_linkcheck_13
+    depends_on:
+      - serve_static
+    image: filiph/linkcheck
+    command:
+      - http://10.253.253.2/docs-csm/en-13
+    networks:
+      csm_documentation:
+        ipv4_address: 10.253.253.7
 networks:
   csm_documentation:
     driver: bridge

--- a/conf/csm.sh
+++ b/conf/csm.sh
@@ -25,7 +25,7 @@
 
 # A list of releases that should be built. Each entry should be X.Y where the
 # branch release/X.Y exists in the docs repo.
-export BRANCHES=("0.9" "1.0" "1.2")
+export BRANCHES=("0.9" "1.0" "1.2" "1.3")
 
 # The documentation repository remote URL. It must be possible to run
 # 'git clone $DOCS_REPO_REMOTE_URL'.
@@ -60,7 +60,7 @@ export HUGO_TEST_COMPOSE_FILE="test.yml"
 export HUGO_DEV_SERVER_COMPOSE_FILE="dev_serve.yml"
 
 # The names of the "linkcheck" services in $HUGO_TEST_COMPOSE_FILE
-export LINKCHECK_SERVICE_NAMES=("linkcheck_en_09" "linkcheck_en_10" "linkcheck_en_11" "linkcheck_en_12")
+export LINKCHECK_SERVICE_NAMES=("linkcheck_en_09" "linkcheck_en_10" "linkcheck_en_11" "linkcheck_en_12" "linkcheck_en_13")
 
 # The name of the "index" files that should be converted to _index.md files in
 # convert-docs-to-hugo.sh

--- a/config.toml
+++ b/config.toml
@@ -40,3 +40,8 @@ disableLandingPageButton = true
     languageName = "1.2"
     weight = 40
     landingPageURL = "/docs-csm/en-12"
+  [languages.en-13]
+    contentDir = "content/1.3"
+    languageName = "1.3"
+    weight = 40
+    landingPageURL = "/docs-csm/en-13"


### PR DESCRIPTION
## Summary and Scope

Add "1.3" item to the versions dropdown at https://cray-hpe.github.io/docs-csm/

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5196](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5196)

## Testing

### Tested on:

  * Local development environment

### Test description:

* Ran build script
* Ensured 1.3 folder is generated under `public/`

## Risks and Mitigations

Low - docs only

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

