### PR TITLE
CRAYSAT-1651: Update HTML builder for SAT 2.5 release

### DIFF
--- a/bin/compose/sat/hugo_prep.sat.yml
+++ b/bin/compose/sat/hugo_prep.sat.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -72,6 +72,20 @@ services:
     image: ubuntu
     environment:
       DOCS_BRANCH: 2.4
+      PRODUCT_NAME: sat
+    volumes:
+      - ${PWD}:/src
+    entrypoint:
+      - /src/bin/convert-docs-to-hugo.sh
+      - --source
+      - /src/docs-sat/
+      - --destination
+      - /src/content
+  hugo_prep_25:
+    container_name: hugo_prep_25
+    image: ubuntu
+    environment:
+      DOCS_BRANCH: 2.5
       PRODUCT_NAME: sat
     volumes:
       - ${PWD}:/src

--- a/bin/compose/sat/test.sat.yml
+++ b/bin/compose/sat/test.sat.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -79,6 +79,17 @@ services:
     networks:
       sat_documentation:
         ipv4_address: 10.253.252.6
+  linkcheck_en_25:
+    build: ${PWD}/bin/compose/build/linkchecker
+    container_name: sat_docs_linkcheck_25
+    depends_on:
+      - serve_static
+    image: filiph/linkcheck
+    command:
+      - http://10.253.252.2/docs-sat/en-25
+    networks:
+      sat_documentation:
+        ipv4_address: 10.253.252.7
 
 networks:
   sat_documentation:

--- a/conf/sat.sh
+++ b/conf/sat.sh
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,7 @@
 
 # A list of releases that should be built. Each entry should be X.Y where the
 # branch release/X.Y exists in the docs repo.
-export BRANCHES=("2.4" "2.3" "2.2" "2.1")
+export BRANCHES=("2.5" "2.4" "2.3" "2.2" "2.1")
 
 # The documentation repository remote URL. It must be possible to run
 # 'git clone $DOCS_REPO_REMOTE_URL'.
@@ -61,7 +61,7 @@ export HUGO_TEST_COMPOSE_FILE="sat/test.sat.yml"
 export HUGO_DEV_SERVER_COMPOSE_FILE="dev_serve.yml"
 
 # The names of the "linkcheck" services in $HUGO_TEST_COMPOSE_FILE
-export LINKCHECK_SERVICE_NAMES=("linkcheck_en_21" "linkcheck_en_22" "linkcheck_en_23" "linkcheck_en_24")
+export LINKCHECK_SERVICE_NAMES=("linkcheck_en_21" "linkcheck_en_22" "linkcheck_en_23" "linkcheck_en_24" "linkcheck_en_25")
 
 # The name of the "index" files that should be converted to _index.md files in
 # convert-docs-to-hugo.sh

--- a/config.sat.toml
+++ b/config.sat.toml
@@ -2,7 +2,7 @@ title = "System Admin Toolkit (SAT)"
 theme = "hugo-theme-learn"
 baseURL = "/docs-sat/"
 languageCode = "en-US"
-defaultContentLanguage = "en-24"
+defaultContentLanguage = "en-25"
 defaultContentLanguageInSubdir = true
 showVisitedLinks = true
 refLinksErrorLevel = "WARNING"
@@ -17,6 +17,11 @@ disableNextPrev = true
 disableLandingPageButton = true
 
 [languages]
+  [languages.en-25]
+    contentDir = "content/2.5"
+    languageName = "2.5"
+    weight = 40
+    landingPageURL = "/docs-sat/en-25"
   [languages.en-24]
     contentDir = "content/2.4"
     languageName = "2.4"


### PR DESCRIPTION
This commit adds configuration for the 2.5 release branch of docs-sat, so that a 2.5 version is built and published to the online docs. This commit modifies conf/sat.sh so that the existence of release/2.5 is expected, adds hugo_prep and linkcheck containers for these branches, and adds a new "language" to the Hugo config for 2.5.

Test Description:
* Ran the following:
** `bin/build.sh sat`
** `bin/test.sh sat`
** `bin/dev.sh sat`, and viewed the docs locally.
** `bin/push.sh sat` (I commented out the line which does the push).

## Summary and Scope

See commit message

## Issues and Related PRs

CRAYSAT-1651

## Testing

See commit message

## Risks and Mitigations

N/A

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
