### PR TITLE
CASMINST-5829 Add 1.4 docs to github pages

### DIFF
--- a/bin/compose/hugo_prep.yml
+++ b/bin/compose/hugo_prep.yml
@@ -89,3 +89,16 @@ services:
       - /src/docs-csm/
       - --destination
       - /src/content/
+  hugo_prep_14:
+    container_name: hugo_prep_14
+    image: ubuntu
+    environment:
+      CSM_BRANCH: 1.4
+    volumes:
+      - ${PWD}:/src
+    entrypoint:
+      - /src/bin/convert-docs-to-hugo.sh
+      - --source
+      - /src/docs-csm/
+      - --destination
+      - /src/content/

--- a/conf/csm.sh
+++ b/conf/csm.sh
@@ -25,7 +25,7 @@
 
 # A list of releases that should be built. Each entry should be X.Y where the
 # branch release/X.Y exists in the docs repo.
-export BRANCHES=("0.9" "1.0" "1.2" "1.3")
+export BRANCHES=("0.9" "1.0" "1.2" "1.3" "1.4")
 
 # The documentation repository remote URL. It must be possible to run
 # 'git clone $DOCS_REPO_REMOTE_URL'.
@@ -60,7 +60,7 @@ export HUGO_TEST_COMPOSE_FILE="test.yml"
 export HUGO_DEV_SERVER_COMPOSE_FILE="dev_serve.yml"
 
 # The names of the "linkcheck" services in $HUGO_TEST_COMPOSE_FILE
-export LINKCHECK_SERVICE_NAMES=("linkcheck_en_09" "linkcheck_en_10" "linkcheck_en_11" "linkcheck_en_12" "linkcheck_en_13")
+export LINKCHECK_SERVICE_NAMES=("linkcheck_en_09" "linkcheck_en_10" "linkcheck_en_11" "linkcheck_en_12" "linkcheck_en_13" "linkcheck_en_14")
 
 # The name of the "index" files that should be converted to _index.md files in
 # convert-docs-to-hugo.sh

--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ title = "Cray System Management (CSM)"
 theme = "hugo-theme-learn"
 baseURL = "/docs-csm/"
 languageCode = "en-US"
-defaultContentLanguage = "en-13"
+defaultContentLanguage = "en-14"
 defaultContentLanguageInSubdir = true
 showVisitedLinks = true
 refLinksErrorLevel = "WARNING"
@@ -45,3 +45,8 @@ disableLandingPageButton = true
     languageName = "1.3"
     weight = 50
     landingPageURL = "/docs-csm/en-13"
+  [languages.en-14]
+    contentDir = "content/1.4"
+    languageName = "1.4"
+    weight = 60
+    landingPageURL = "/docs-csm/en-14"


### PR DESCRIPTION
## Summary and Scope

We ship csm 1.4 to customers now, so we need to provide docs.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5829](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5829)

## Testing
### Tested on:

  * Local development environment
  * CI/CD run

### Test description:

Statistics generated by dry run (no push):

    hugo_build    |                    | EN-09 | EN-10 | EN-12 | EN-13 | EN-14  
    hugo_build    | -------------------+-------+-------+-------+-------+--------
    hugo_build    |   Pages            |   174 |   716 |   964 |  1045 |  1067  
    hugo_build    |   Paginator pages  |     0 |     0 |     0 |     0 |     0  
    hugo_build    |   Non-page files   |    89 |   285 |   372 |   418 |   468  
    hugo_build    |   Static files     |    76 |    76 |    76 |    76 |    76  
    hugo_build    |   Processed images |     0 |     0 |     0 |     0 |     0  
    hugo_build    |   Aliases          |     1 |     0 |     0 |     0 |     0  
    hugo_build    |   Sitemaps         |     2 |     1 |     1 |     1 |     1  
    hugo_build    |   Cleaned          |     0 |     0 |     0 |     0 |     0  

## Risks and Mitigations
Low - docs only